### PR TITLE
missing bootstrap when installing droopler with composer

### DIFF
--- a/web/themes/custom/droopler_subtheme/package.json
+++ b/web/themes/custom/droopler_subtheme/package.json
@@ -14,5 +14,8 @@
     "gulp-watch": "^5.0.1",
     "pump": "^1.0.2",
     "yargs": "^15.1.0"
+  },
+  "dependencies": {
+    "bootstrap": "^4.4.1"
   }
 }


### PR DESCRIPTION
* when trying to gulp compile - the bootstrap is missing