### PR TITLE
Add missing instruction to return to the root folder before installing the subtheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ $ npm install --global gulp-cli
 $ cd web/profiles/contrib/droopler/themes/custom/droopler_theme
 $ npm install
 $ gulp compile
+$ cd -
 $ cd web/themes/custom/droopler_subtheme
 $ npm install
 $ gulp compile


### PR DESCRIPTION
The instructions for installing the Node and gulp dependencies for the theme and subtheme are missing one step: to return to the project root in between the two tasks.

This is a minor improvement but it can help people who are not very familiar with the CLI.